### PR TITLE
Minimize image bloat and use openjdk-8 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
 # vim:set ft=dockerfile:
 FROM postgres:9.4
-ENV TERM=xterm-256color DEBIAN_FRONTEND=noninteractive LC_ALL=C
+ENV TERM=xterm-256color
 
 RUN echo deb http://ftp.us.debian.org/debian jessie main > /etc/apt/sources.list && \
     echo deb http://ftp.us.debian.org/debian jessie-backports main >> /etc/apt/sources.list && \
-    apt-get update && \
-    apt-get -y upgrade && apt-get dist-upgrade && \
-    apt-get purge $(dpkg -l | awk '/^rc/ { print $2 }') && \
-    apt-get autoremove && \
     echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" > /etc/apt/sources.list.d/webupd8team-java.list && \
     echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list.d/webupd8team-java.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886 && \
@@ -32,7 +28,6 @@ RUN echo deb http://ftp.us.debian.org/debian jessie main > /etc/apt/sources.list
     apt-get -y clean autoclean autoremove && \
     rm -rf ~/.m2 && rm -rf pljava/ /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV DEBIAN_FRONTEND teletype
 ADD /docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,41 @@
 # vim:set ft=dockerfile:
 FROM postgres:9.4
-ENV TERM xterm-256color
+ENV TERM=xterm-256color DEBIAN_FRONTEND=noninteractive LC_ALL=C
 
-RUN echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/sources.list && \
+RUN echo deb http://ftp.us.debian.org/debian jessie main > /etc/apt/sources.list && \
+    echo deb http://ftp.us.debian.org/debian jessie-backports main >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get -y upgrade && \
-    apt-get dist-upgrade && \
+    apt-get -y upgrade && apt-get dist-upgrade && \
     apt-get purge $(dpkg -l | awk '/^rc/ { print $2 }') && \
     apt-get autoremove && \
     echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" > /etc/apt/sources.list.d/webupd8team-java.list && \
     echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list.d/webupd8team-java.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886 
-
-RUN apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes install git && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886 && \
+    apt-get update && \
+    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes --no-install-recommends install git ca-certificates && \
     git clone https://github.com/tada/pljava.git && \
-    apt-get -y remove --purge --auto-remove git 
-
-RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \    
-    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes install g++ maven && \
-    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes install postgresql-server-dev-9.4 libpq-dev && \
-    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes install libecpg-dev libkrb5-dev && \
-    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes install oracle-java8-installer && \
+    apt-get -y remove --purge --auto-remove git && \
+    echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
+    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes --no-install-recommends install g++ maven && \
+    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes --no-install-recommends install postgresql-server-dev-9.4 libpq-dev && \
+    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes --no-install-recommends install libecpg-dev libkrb5-dev && \
+    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes --no-install-recommends install oracle-java8-installer && \
     export PGXS=/usr/lib/postgresql/9.4/lib/pgxs/src/makefiles/pgxs.mk && \
     cd pljava && \
     mvn clean install && \
     java -jar /pljava/pljava-packaging/target/pljava-pg9.4-amd64-Linux-gpp.jar && \
-    cd ../ && \ 
+    cd ../ && \
     cp pljava/pljava-examples/target/*.jar / && \
     /bin/bash -c 'for file in *.jar ; do mv $file pljava-examples.jar ; done' && \
-    rm -rf pljava && \ 
     apt-get -y remove --purge --auto-remove g++ maven postgresql-server-dev-9.4 libpq-dev libecpg-dev libkrb5-dev oracle-java8-installer && \
-    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes install openjdk-8-jdk-headless && \ 
-    apt-get -y clean autoclean autoremove
+    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes --no-install-recommends install openjdk-8-jdk-headless && \
+    apt-get -y clean autoclean autoremove && \
+    rm -rf ~/.m2 && rm -rf pljava/ /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+ENV DEBIAN_FRONTEND teletype
 ADD /docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 5432
 CMD ["postgres"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,37 @@
 # vim:set ft=dockerfile:
 FROM postgres:9.4
-
-RUN apt-get update
-RUN apt-get -y upgrade
-RUN apt-get dist-upgrade
-RUN apt-get purge $(dpkg -l | awk '/^rc/ { print $2 }')
-RUN apt-get autoremove
-
-RUN echo "deb http://http.debian.net/debian jessie-backports main" >>/etc/apt/sources.list
-
-RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" > /etc/apt/sources.list.d/webupd8team-java.list
-RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list.d/webupd8team-java.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886
-RUN apt-get update
-
 ENV TERM xterm-256color
-RUN apt-get -y install git maven 
-RUN apt-get -y install postgresql-server-dev-9.4 libpq-dev libecpg-dev
-RUN apt-get -y install g++ libkrb5-dev
 
-RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-get -y install oracle-java8-installer
+RUN echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get -y upgrade && \
+    apt-get dist-upgrade && \
+    apt-get purge $(dpkg -l | awk '/^rc/ { print $2 }') && \
+    apt-get autoremove && \
+    echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" > /etc/apt/sources.list.d/webupd8team-java.list && \
+    echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list.d/webupd8team-java.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886 
 
-RUN git clone https://github.com/tada/pljava.git
-RUN export PGXS=/usr/lib/postgresql/9.4/lib/pgxs/src/makefiles/pgxs.mk
-WORKDIR pljava 
-RUN mvn clean
-RUN mvn install
-RUN java -jar /pljava/pljava-packaging/target/pljava-pg9.4-amd64-Linux-gpp.jar
+RUN apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes install git && \
+    git clone https://github.com/tada/pljava.git && \
+    apt-get -y remove --purge --auto-remove git 
+
+RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \    
+    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes install g++ maven && \
+    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes install postgresql-server-dev-9.4 libpq-dev && \
+    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes install libecpg-dev libkrb5-dev && \
+    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes install oracle-java8-installer && \
+    export PGXS=/usr/lib/postgresql/9.4/lib/pgxs/src/makefiles/pgxs.mk && \
+    cd pljava && \
+    mvn clean install && \
+    java -jar /pljava/pljava-packaging/target/pljava-pg9.4-amd64-Linux-gpp.jar && \
+    cd ../ && \ 
+    cp pljava/pljava-examples/target/*.jar / && \
+    /bin/bash -c 'for file in *.jar ; do mv $file pljava-examples.jar ; done' && \
+    rm -rf pljava && \ 
+    apt-get -y remove --purge --auto-remove g++ maven postgresql-server-dev-9.4 libpq-dev libecpg-dev libkrb5-dev oracle-java8-installer && \
+    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes install openjdk-8-jdk-headless && \ 
+    apt-get -y clean autoclean autoremove
 
 ADD /docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
 

--- a/docker-entrypoint-initdb.d/01_init_pljava.sql
+++ b/docker-entrypoint-initdb.d/01_init_pljava.sql
@@ -1,7 +1,7 @@
-SET pljava.libjvm_location TO '/usr/lib/jvm/java-8-oracle/jre/lib/amd64/server/libjvm.so';
+SET pljava.libjvm_location TO '/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so';
 ALTER DATABASE postgres SET pljava.libjvm_location FROM CURRENT;
 CREATE EXTENSION pljava;
-SELECT sqlj.install_jar('file:///pljava/pljava-examples/target/pljava-examples-1.6.0-SNAPSHOT.jar', 'examples', true);
+SELECT sqlj.install_jar('file:///pljava-examples.jar', 'examples', true);
 SHOW search_path;
 SELECT sqlj.get_classpath('javatest');
 SELECT sqlj.set_classpath('javatest', 'examples');


### PR DESCRIPTION
Refactored this Dockerfile to produce an image as small as possible. Pulling from dockerhub gives a 1.4GB image while these changes results in a 470MB image.

I've also used openjdk-8 as downstream users are not technically accepting the oracle java end-user license agreement. 

Have a look and let me know what you think.
